### PR TITLE
remove shared-database add-on

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -15,8 +15,6 @@ config_vars:
     PATH: "/usr/local/bin:/usr/bin:/bin:${ANT_HOME}/bin"
     JAVA_OPTS: "-Xmx384m -Xss512k -XX:+UseCompressedOops"
     ANT_OPTS: "-Xmx384m -Xss512k -XX:+UseCompressedOops"
-addons:
-    shared-database: 5mb
 default_process_types:
     web: ant run
 EOF


### PR DESCRIPTION
The 'shared-database' add-on doesn't exist - so will cause an error:

> Push failed: Could not communicate with vendor, please try again later

Removing the add-on fixes the issue
